### PR TITLE
forgot to remove the /api prefix in prod properties

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -7,6 +7,3 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 
 spring.flyway.enabled=true
-
-# API prefix for Traefik routing
-server.servlet.context-path=/api


### PR DESCRIPTION
we dont need this anymore as the api (backend) url is api.adoptpetsforall.com.
this was making it need two /api contexts to call anything from the url